### PR TITLE
Added a Signed Search Key example

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,16 +281,16 @@ client
 Creating a search key that will only return the title field.
 
 ```javascript
-const readOnlyApiKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
-const apiKeyName = 'search-key'
+const publicSearchKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
+const publicSearchKeyName = 'search-key'
 const enforcedOptions = {
   result_fields: { title: { raw: {} } },
   filters: { world_heritage_site: 'true' }
 }
 
 const signedSearchKey = AppSearchClient.createSignedSearchKey(
-  readOnlyApiKey,
-  apiKeyName,
+  publicSearchKey,
+  publicSearchKeyName,
   enforcedOptions
 )
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,28 @@ client
   .catch(error => console.log(error.errorMessages))
 ```
 
+##### Create a Signed Search Key
+
+Creating a search key that will only return the title field.
+
+```javascript
+const readOnlyApiKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
+const apiKeyName = 'search-key'
+const enforcedOptions = {
+  result_fields: { title: { raw: {} } },
+  filters: { world_heritage_site: 'true' }
+}
+
+const signedSearchKey = AppSearchClient.createSignedSearchKey(
+  readOnlyApiKey,
+  apiKeyName,
+  enforcedOptions
+)
+
+const client = new AppSearchClient('host-c5s2mj', signedSearchKey)
+client.search('sample-engine', 'everglade')
+```
+
 ## Running tests
 
 The specs in this project use [node-replay](https://github.com/assaf/node-replay) to capture responses.


### PR DESCRIPTION
I noticed that this was missing. We'll need to link to this section from the documentation site, now that we've removed the examples there.