### PR TITLE
Added Meta Engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ client
 const engineName = 'favorite-videos'
 
 client
-  .createEngine(engineName)
+  .createEngine(engineName, { language: 'en' })
   .then(response => console.log(response))
   .catch(error => console.log(error.errorMessages))
 ```
@@ -309,22 +309,87 @@ const client = new AppSearchClient('host-c5s2mj', signedSearchKey)
 client.search('sample-engine', 'everglade')
 ```
 
-## Running tests
+##### Create a Meta Engine
 
-The specs in this project use [node-replay](https://github.com/assaf/node-replay) to capture responses.
+```javascript
+const engineName = 'my-meta-engine'
 
-To capture new responses, run tests with the following commands:
-
-```bash
-nvm use
-REPLAY=record npm test
+client
+  .createMetaEngine(engineName, ['source-engine-1', 'source-engine-2'])
+  .then(response => console.log(response))
+  .catch(error => console.log(error.errorMessages))
 ```
 
-Otherwise:
+##### Add a Source Engine to a Meta Engine
+
+```javascript
+const engineName = 'my-meta-engine'
+
+client
+  .addMetaEngineSources(engineName, ['source-engine-3'])
+  .then(response => console.log(response))
+  .catch(error => console.log(error.errorMessages))
+```
+
+##### Remove a Source Engine from a Meta Engine
+
+```javascript
+const engineName = 'my-meta-engine'
+
+client
+  .deleteMetaEngineSources(engineName, ['source-engine-3'])
+  .then(response => console.log(response))
+  .catch(error => console.log(error.errorMessages))
+```
+
+##### Creating Engines
+
+```javascript
+const engineName = 'my-meta-engine'
+
+client
+  .createEngine(engineName, {
+    type: 'meta',
+    source_engines: ['source-engine-1', 'source-engine-2']
+  })
+  .then(response => console.log(response))
+  .catch(error => console.log(error.errorMessages))
+```
+
+## Running tests
 
 ```bash
 npm test
 ```
+
+The specs in this project use [node-replay](https://github.com/assaf/node-replay) to capture fixtures.
+
+New fixtures should be captured from a running instance of App Search.
+
+To capture new fixtures, run a command like the following:
+
+```
+nvm use
+HOST_IDENTIFIER=host-c5s2mj API_KEY=private-b94wtaoaym2ovdk5dohj3hrz REPLAY=record npm run test -- -g 'should create a meta engine'
+```
+
+To break that down a little...
+- `HOST_IDENTIFIER` - Use this to override the fake value used in tests with an actual valid value for your App Search instance to record from
+- `API_KEY` - Use this to override the fake value used in tests with an actual valid value for your App Search instance to record from
+- `REPLAY=record` - Tells replay to record a new response if one doesn't already exist
+- `npm run test` - Run the tests
+- `-- -g 'should create a meta engine'` - Limit the tests to ONLY run the new test you've created, 'should create a meta engine' for example
+
+This will create a new fixture, make sure you manually edit that fixture to replace the host identifier and api key
+recorded in that fixture with the values the tests use.
+
+You'll also need to make sure that fixture is located in the correctly named directory under `fixtures` according to the host that was used.
+
+You'll know if something is not right because this will error when you run `npm run test` with an error like:
+```
+Error: POST https://host-c5s2mj.api.swiftype.com:443/api/as/v1/engines refused: not recording and no network access
+```
+
 
 ## FAQ 🔮
 

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
@@ -1,0 +1,34 @@
+POST /api/as/v1/engines
+x-swiftype-client: elastic-app-search-node
+x-swiftype-client-version: 7.5.0
+content-type: application/json
+host: host-c5s2mj.api.swiftype.com
+authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
+accept: application/json
+body: {\"name\":\"new-engine\",\"language\":\"en\"}
+
+HTTP/1.1 200 OK
+date: Wed, 12 Feb 2020 20:30:58 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-swiftype-backend-region: dal
+x-swiftype-backend-datacenter: dal10
+x-swiftype-backend-node: app-api02b.dal10
+x-ratelimit-limit: 15000
+x-ratelimit-remaining: 14999
+etag: W/"86b23aaaf3bab9826cdf8c71cbc909f2"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 047d3cd04240c5599dd99b3692df7a8a
+x-runtime: 0.583643
+x-swiftype-frontend-datacenter: dal10
+x-swiftype-frontend-node: web02b.dal10
+x-swiftype-edge-datacenter: dal10
+x-swiftype-edge-node: web02b.dal10
+
+{"name":"new-engine","type":"default","language":"en"}

--- a/fixtures/localhost-3002/15815391173475749
+++ b/fixtures/localhost-3002/15815391173475749
@@ -1,0 +1,24 @@
+POST /api/as/v1/engines
+x-swiftype-client: elastic-app-search-node
+x-swiftype-client-version: 7.5.0
+content-type: application/json
+host: localhost:3002
+authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
+accept: application/json
+body: {\"name\":\"new-meta-engine\",\"type\":\"meta\",\"source_engines\":[\"source-engine-1\",\"source-engine-2\"]}
+
+HTTP/1.1 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-app-search-version: 7.7.0
+content-type: application/json; charset=utf-8
+vary: Origin
+etag: W/"cdb1493c20f29d2310c3222758a6c07b"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: a644b984-1214-4b9c-992e-0382e4443bf6
+x-runtime: 0.534623
+connection: close
+transfer-encoding: chunked
+
+{"name":"new-meta-engine","type":"meta","source_engines":["source-engine-1","source-engine-2"]}

--- a/fixtures/localhost-3002/15815978342879229
+++ b/fixtures/localhost-3002/15815978342879229
@@ -1,0 +1,24 @@
+POST /api/as/v1/engines/new-meta-engine/source_engines
+x-swiftype-client: elastic-app-search-node
+x-swiftype-client-version: 7.5.0
+content-type: application/json
+host: localhost:3002
+authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
+accept: application/json
+body: [\"source-engine-3\"]
+
+HTTP/1.1 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-app-search-version: 7.7.0
+content-type: application/json; charset=utf-8
+vary: Origin
+etag: W/"3d866b390e18c1bf51503b81707dc011"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 95a0ef7d-ea6a-48f7-ba28-826f62c3e4fc
+x-runtime: 0.355023
+connection: close
+transfer-encoding: chunked
+
+{"name":"new-meta-engine","type":"meta","source_engines":["source-engine-1","source-engine-2","source-engine-3"]}

--- a/fixtures/localhost-3002/158159799829857287
+++ b/fixtures/localhost-3002/158159799829857287
@@ -1,0 +1,24 @@
+DELETE /api/as/v1/engines/new-meta-engine/source_engines
+x-swiftype-client: elastic-app-search-node
+x-swiftype-client-version: 7.5.0
+content-type: application/json
+host: localhost:3002
+authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
+accept: application/json
+body: [\"source-engine-3\"]
+
+HTTP/1.1 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-app-search-version: 7.7.0
+content-type: application/json; charset=utf-8
+vary: Origin
+etag: W/"cdb1493c20f29d2310c3222758a6c07b"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: a0cc4718-3a7d-4b60-9cd2-32684a582e96
+x-runtime: 0.305840
+connection: close
+transfer-encoding: chunked
+
+{"name":"new-meta-engine","type":"meta","source_engines":["source-engine-1","source-engine-2"]}

--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -175,12 +175,36 @@ class AppSearchClient {
    * Create a new engine
    *
    * @param {String} engineName unique Engine name
+   * @param {Object} options
    * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
    */
-  createEngine(engineName) {
+  createEngine(engineName, options) {
     return this.client.post(`engines`, {
-      name: engineName
+      name: engineName,
+      ...options
     })
+  }
+
+  /**
+   * Add a Source Engine to a Meta Engine
+   *
+   * @param {String} engineName Name of Meta Engine
+   * @param {Array[String]} sourceEngines Names of Engines to use as Source Engines
+   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
+   */
+  addMetaEngineSources(engineName, sourceEngines) {
+    return this.client.post(`engines/${engineName}/source_engines`, sourceEngines)
+  }
+
+  /**
+   * Remove a Source Engine from a Meta Engine
+   *
+   * @param {String} engineName Name of Meta Engine
+   * @param {Array[String]} sourceEngines Names of existing Source Engines to remove
+   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
+   */
+  deleteMetaEngineSources(engineName, sourceEngines) {
+    return this.client.delete(`engines/${engineName}/source_engines`, sourceEngines)
   }
 
   /**
@@ -240,6 +264,21 @@ class AppSearchClient {
    */
   updateCuration(engineName, curationId, newCuration) {
     return this.client.put(`engines/${encodeURIComponent(engineName)}/curations/${encodeURIComponent(curationId)}`, newCuration)
+  }
+
+  /**
+   * Create a new meta engine
+   *
+   * @param {String} engineName unique Engine name
+   * @param {Array[String]} sourceEngines list of engine names to use as source engines
+   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
+   */
+  createMetaEngine(engineName, sourceEngines) {
+    return this.client.post(`engines`, {
+      name: engineName,
+      type: 'meta',
+      source_engines: sourceEngines
+    })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/elastic/app-search-node#readme",
   "devDependencies": {
     "mocha": "^5.0.0",
-    "replay": "^2.1.2"
+    "replay": "~2.4.0"
   },
   "dependencies": {
     "request": "^2.81.0",


### PR DESCRIPTION
- Added instructions for capturing new fixtures, because it is a clunky process and hard to remember
- Added support for overriding host and api key when recording fixtures
- Added support for capturing fixtures from self-managed app search
- Added support for Meta Engines
- Added language support for Engine creation
- Fixed minor version of `node-replay` for a consistent experience during development since we do not include a package-lock.json file