### PR TITLE
Fix JSDoc return type annotation

### DIFF
--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -150,7 +150,7 @@ class AppSearchClient {
    *
    * @param {String} engineName unique Engine name
    * @param {Array<String>} ids Array of document ids to be retrieved
-   * @returns {Promise<Object>} a Promise that returns an array of documents, otherwise throws an Error.
+   * @returns {Promise<Array<Object>>} a Promise that returns an array of documents, otherwise throws an Error.
    */
   getDocuments(engineName, ids) {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/documents`, ids)


### PR DESCRIPTION
I believe the return type annotation is incorrect given the existing description:

> a Promise that returns **an array of documents**, otherwise throws an Error.