### PR TITLE
Update Search method to use POST

### DIFF
--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -54,7 +54,7 @@ class AppSearchClient {
    */
   search(engineName, query, options = {}) {
     options = Object.assign({}, options, { query })
-    return this.client.get(`engines/${encodeURIComponent(engineName)}/search`, options)
+    return this.client.post(`engines/${encodeURIComponent(engineName)}/search`, options)
   }
 
   /**


### PR DESCRIPTION
I could not get this to work (error about query not being sent) without swapping over to the POST method.

This was with a 14-day trial version of App Search.

edit: signed the agreement