### PR TITLE
Update docs to be consistent with Elastic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ client
 
 ##### Create a Signed Search Key
 
-Creating a search key that will only return the title field.
+Creating a signed search key that will only return the title field. Note: choose a private key with read access enabled to sign the Signed Search Key.
 
 ```javascript
-const publicSearchKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
+const readAccessPrivateKey = 'private-xxxxxxxxxxxxxxxxxxxxxxxx'
 // This name must match the name of the key above from your App Search dashboard
-const publicSearchKeyName = 'search-key'
+const readAccessPrivateKeyName = 'private-key'
 const enforcedOptions = {
   result_fields: { title: { raw: {} } },
   filters: { world_heritage_site: 'true' }
@@ -387,8 +387,8 @@ const signOptions = {
 }
 
 const signedSearchKey = AppSearchClient.createSignedSearchKey(
-  publicSearchKey,
-  publicSearchKeyName,
+  readAccessPrivateKey,
+  readAccessPrivateKeyName,
   enforcedOptions,
   signOptions
 )

--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ client
 
 ##### Create a Signed Search Key
 
-Creating a signed search key that will only return the title field. Note: choose a private key with read access enabled to sign the Signed Search Key.
+Signed search keys keep your read-only Private API Keys secret and restrict what a user can search over. They can be used to restrict top-level search options. The example below creates a signed search key that will only return the `title` field.
+
+See https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-signed for more options and documentation.
 
 ```javascript
 const readAccessPrivateKey = 'private-xxxxxxxxxxxxxxxxxxxxxxxx'


### PR DESCRIPTION
See https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-signed.

The docs pretty clearly state you need to use a private key with read access.

This caused confusion in https://github.com/elastic/sdh-enterprise-search/issues/636.