### PR TITLE
Added basic TS definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ try {
     );
   }
 } catch (e) {
-  console.log(e);
+  console.error(e);
 }
 ```
 
@@ -161,7 +161,7 @@ try {
     );
   }
 } catch (e) {
-  console.log(e);
+  console.error(e);
 }
 ```
 
@@ -320,7 +320,7 @@ try {
   );
   console.log(`Indexed ${singleDocumentResponse.id} succesfully`);
 } catch (e) {
-  console.log(e);
+  console.error(e);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Using this client assumes that you have already an instance of [Elastic App Sear
 The client is configured using the `baseUrlFn` and `apiKey` parameters.
 
  ```javascript
-const apiKey = 'private-mu75psc5egt9ppzuycnc2mc3'
-const baseUrlFn = () => 'http://localhost:3002/api/as/v1/'
-const client = new AppSearchClient(undefined, apiKey, baseUrlFn)
+const apiKey = "private-mu75psc5egt9ppzuycnc2mc3";
+const baseUrlFn = () => "http://localhost:3002/api/as/v1/";
+const client = new AppSearchClient(undefined, apiKey, baseUrlFn);
 ```
 
 Note:
@@ -61,9 +61,9 @@ The `hostIdentifier` can be found within the [Credentials](https://app.swiftype.
 
 ```javascript
 const AppSearchClient = require('@elastic/app-search-node')
-const hostIdentifier = 'host-c5s2mj'
-const apiKey = 'private-mu75psc5egt9ppzuycnc2mc3'
-const client = new AppSearchClient(hostIdentifier, apiKey)
+const hostIdentifier = "host-c5s2mj";
+const apiKey = "private-mu75psc5egt9ppzuycnc2mc3";
+const client = new AppSearchClient(hostIdentifier, apiKey);
 ```
 
 ### API Methods
@@ -71,26 +71,45 @@ const client = new AppSearchClient(hostIdentifier, apiKey)
 ##### Indexing: Creating or Replacing Documents
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 const documents = [
   {
-    id: 'INscMGmhmX4',
-    url: 'https://www.youtube.com/watch?v=INscMGmhmX4',
-    title: 'The Original Grumpy Cat',
-    body: 'A wonderful video of a magnificent cat.'
+    id: "INscMGmhmX4",
+    url: "https://www.youtube.com/watch?v=INscMGmhmX4",
+    title: "The Original Grumpy Cat",
+    body: "A wonderful video of a magnificent cat.",
   },
   {
-    id: 'JNDFojsd02',
-    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-    title: 'Another Grumpy Cat',
-    body: 'A great video of another cool cat.'
-  }
-]
+    id: "JNDFojsd02",
+    url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    title: "Another Grumpy Cat",
+    body: "A great video of another cool cat.",
+  },
+];
 
-client
-  .indexDocuments(engineName, documents)
-  .then(response => console.log(response))
-  .catch(error => console.log(error))
+try {
+  const documentResponses = await client.indexDocuments(engineName, document);
+  const succesfullyIndexedDocumentIds = documentResponses
+    .filter((documentResponse) => documentResponse.errors.length === 0)
+    .map((documentResponse) => documentResponse.id)
+    .join(", ");
+  console.log(
+    `Documents indexed successfully: ${succesfullyIndexedDocumentIds}`
+  );
+
+  const failures = documentResponses.filter(
+    (documentResponse) => documentResponse.errors.length > 0
+  );
+  if (failures.length > 0) {
+    console.log(
+      `Other documents failed with errors: ${failures
+        .map((documentResponse) => documentResponse.errors)
+        .join(", ")}`
+    );
+  }
+} catch (e) {
+  console.log(e);
+}
 ```
 
 Note that this API will not throw on an indexing error. Errors are inlined in the response body per document:
@@ -109,263 +128,312 @@ Note that this API will not throw on an indexing error. Errors are inlined in th
 ##### Indexing: Updating Documents (Partial Updates)
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 const documents = [
   {
-    id: 'INscMGmhmX4',
-    title: 'Updated title'
-  }
-]
+    id: "INscMGmhmX4",
+    title: "Updated title",
+  },
+  {
+    id: "JNDFojsd02",
+    title: "Updated title",
+  },
+];
 
-client
-  .updateDocuments(engineName, documents)
-  .then(response => console.log(response))
-  .catch(error => console.log(error))
+try {
+  const documentResponses = await client.updateDocuments(engineName, document);
+  const succesfullyIndexedDocumentIds = documentResponses
+    .filter((documentResponse) => documentResponse.errors.length === 0)
+    .map((documentResponse) => documentResponse.id)
+    .join(", ");
+  console.log(
+    `Documents updated successfully: ${succesfullyIndexedDocumentIds}`
+  );
+
+  const failures = documentResponses.filter(
+    (documentResponse) => documentResponse.errors.length > 0
+  );
+  if (failures.length > 0) {
+    console.log(
+      `Other documents failed with errors: ${failures
+        .map((documentResponse) => documentResponse.errors)
+        .join(", ")}`
+    );
+  }
+} catch (e) {
+  console.log(e);
+}
 ```
 
 
 ##### Retrieving Documents
 
 ```javascript
-const engineName = 'favorite-videos'
-const documentIds = ['INscMGmhmX4', 'JNDFojsd02']
+const engineName = "favorite-videos";
+const documentIds = ["INscMGmhmX4", "JNDFojsd02"];
 
-client
-  .getDocuments(engineName, documentIds)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const documents = await client.getDocuments(engineName, documentIds);
+  // documents that are not found return as null
+  console.log(documents.filter((document) => document !== null));
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Listing Documents
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
+const documentIds = ["INscMGmhmX4", "JNDFojsd02"];
 
-// Without paging
-client
-  .listDocuments(engineName)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
-
-// With paging
-client
-  .listDocuments(engineName, { page: { size: 10, current: 1 } })
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const documents = await client.getDocuments(engineName, documentIds);
+  // documents that are not found return as null
+  console.log(documents.filter((document) => document !== null));
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Destroying Documents
 
 ```javascript
-const engineName = 'favorite-videos'
-const documentIds = ['INscMGmhmX4', 'JNDFojsd02']
+const engineName = "favorite-videos";
+const documentIds = ["INscMGmhmX4", "JNDFojsd02"];
 
-client
-  .destroyDocuments(engineName, documentIds)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const response = await client.destroyDocuments(engineName, documentIds);
+  const deltedIds = response.filter((r) => r.deleted === true).map((r) => r.id);
+  console.log(`Deleted documents ${deltedIds.join(", ")}`);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Listing Engines
 
 ```javascript
-client
-  .listEngines({ page: { size: 10, current: 1 } })
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engines = await client.listEngines({ page: { size: 10, current: 1 } });
+  engines.results.forEach((r) => console.log(r));
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Retrieving Engines
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 
-client
-  .getEngine(engineName)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.getEngine(engineName);
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Creating Engines
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 
-client
-  .createEngine(engineName, { language: 'en' })
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.createEngine(engineName, { language: "en" });
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Destroying Engines
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 
-client
-  .destroyEngine(engineName)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const response = await client.destroyEngine(engineName);
+  console.log(response);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Searching
 
 ```javascript
-const engineName = 'favorite-videos'
-const query = 'cat'
-const searchFields = { title: {} }
-const resultFields = { title: { raw: {} } }
-const options = { search_fields: searchFields, result_fields: resultFields }
+const engineName = "favorite-videos";
+const query = "cat";
+const options = {
+  search_fields: { title: {} },
+  result_fields: { title: { raw: {} } },
+};
 
-client
-  .search(engineName, query, options)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const response = await client.search(engineName, query);
+  console.log(response.results);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Multi-Search
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 const searches = [
-  { query: 'cat', options: {
+  {
+    query: "cat",
+    options: {
       search_fields: { title: {} },
-      result_fields: { title: { raw: {} } }
-  } },
-  { query: 'grumpy', options: {} }
-]
+      result_fields: { title: { raw: {} } },
+    },
+  },
+  { query: "grumpy" },
+];
 
-client
-  .multiSearch(engineName, searches)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const responses = await client.multiSearch(engineName, query);
+  console.log(responses);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Query Suggestion
 
 ```javascript
-const engineName = 'favorite-videos'
-const options = {
-  size: 3,
-  types: {
-    documents: {
-      fields: ['title']
-    }
-  }
-}
+const engineName = "favorite-videos";
+const document = {
+  id: "INscMGmhmX4",
+  url: "https://www.youtube.com/watch?v=INscMGmhmX4",
+  title: "The Original Grumpy Cat",
+  body: "A wonderful video of a magnificent cat.",
+};
 
-client
-  .querySuggestion(engineName, 'cat', options)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const singleDocumentResponse = await client.indexDocument(
+    engineName,
+    document
+  );
+  console.log(`Indexed ${singleDocumentResponse.id} succesfully`);
+} catch (e) {
+  console.log(e);
+}
 ```
 
 ##### Listing Curations
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 
-client
-  .listCurations(engineName)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
-
-// Pagination details are optional
-const paginationDetails = {
-        page: {
-          current: 2,
-          size: 10
-        }
-      }
-
-client
-  .listCurations(engineName, paginationDetails)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const curationsList = await client.listCurations(engineName, {
+    page: { size: 10, current: 1 },
+  });
+  curationsList.results.forEach((r) => console.log(r));
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Retrieving Curations
 
 ```javascript
-const engineName = 'favorite-videos'
-const curationId = 'cur-7438290'
+const engineName = "favorite-videos";
+const curationId = "cur-7438290";
 
-client
-  .getCuration(engineName, curationId)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const curation = await client.getCuration(engineName, curationId);
+  console.log(curation);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Creating Curations
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 const newCuration = {
-  queries: ['cat blop'],
-  promoted: ['Jdas78932'],
-  hidden: ['INscMGmhmX4', 'JNDFojsd02']
-}
+  queries: ["cat blop"],
+  promoted: ["Jdas78932"],
+};
 
-client
-  .createCuration(engineName, newCuration)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const curation = await client.createCuration(engineName, newCuration);
+  console.log(curation);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Updating Curations
 
 ```javascript
-const engineName = 'favorite-videos'
-const curationId = 'cur-7438290'
-// "queries" is required, either "promoted" or "hidden" is required.
-// Values sent for all fields will overwrite existing values.
+const engineName = "favorite-videos";
+const curationId = "cur-7438290";
 const newDetails = {
-  queries: ['cat blop'],
-  promoted: ['Jdas78932', 'JFayf782']
-}
+  queries: ["cat blop"],
+  promoted: ["Jdas78932", "JFayf782"],
+};
 
-client
-  .updateCuration(engineName, curationId, newDetails)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const curation = await client.updateCuration(
+    engineName,
+    curationId,
+    newDetails
+  );
+  console.log(curation);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Deleting Curations
 
 ```javascript
-const engineName = 'favorite-videos'
-const curationId = 'cur-7438290'
+const engineName = "favorite-videos";
+const curationId = "cur-7438290";
 
-client
-  .destroyCuration(engineName, curationId)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const response = await client.destroyCuration(engineName, curationId);
+  console.log(response.deleted);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Retrieving Schemas
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 
-client
-  .getSchema(engineName)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const schema = await client.getSchema(engineName);
+  console.log(schema);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Updating Schemas
 
 ```javascript
-const engineName = 'favorite-videos'
+const engineName = "favorite-videos";
 const schema = {
-  views: 'number',
-  created_at: 'date'
-}
+  views: "number",
+  created_at: "date",
+};
 
-client
-  .updateSchema(engineName, schema)
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const updatedSchema = await client.updateSchema(engineName, schema);
+  console.log(updatedSchema);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Create a Signed Search Key
@@ -373,77 +441,89 @@ client
 Creating a search key that will only return the title field.
 
 ```javascript
-const publicSearchKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
+const publicSearchKey = "search-xxxxxxxxxxxxxxxxxxxxxxxx";
 // This name must match the name of the key above from your App Search dashboard
-const publicSearchKeyName = 'search-key'
+const publicSearchKeyName = "search-key";
 const enforcedOptions = {
   result_fields: { title: { raw: {} } },
-  filters: { world_heritage_site: 'true' }
-}
+  filters: { world_heritage_site: "true" },
+};
 
 // Optional. See https://github.com/auth0/node-jsonwebtoken#usage for all options
 const signOptions = {
-  expiresIn: '5 minutes'
-}
+  expiresIn: "5 minutes",
+};
 
 const signedSearchKey = AppSearchClient.createSignedSearchKey(
   publicSearchKey,
   publicSearchKeyName,
   enforcedOptions,
   signOptions
-)
+);
 
-const baseUrlFn = () => 'http://localhost:3002/api/as/v1/'
-const client = new AppSearchClient(undefined, signedSearchKey, baseUrlFn)
+const baseUrlFn = () => "http://localhost:3002/api/as/v1/";
+const client = new AppSearchClient(undefined, signedSearchKey, baseUrlFn);
 
-client.search('sample-engine', 'everglade')
+client.search("sample-engine", "everglade");
 ```
 
 ##### Create a Meta Engine
 
 ```javascript
-const engineName = 'my-meta-engine'
+const engineName = "my-meta-engine";
 
-client
-  .createMetaEngine(engineName, ['source-engine-1', 'source-engine-2'])
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.createMetaEngine(engineName, [
+    "source-engine-1",
+    "source-engine-2",
+  ]);
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Add a Source Engine to a Meta Engine
 
 ```javascript
-const engineName = 'my-meta-engine'
+const engineName = "my-meta-engine";
 
-client
-  .addMetaEngineSources(engineName, ['source-engine-3'])
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.addMetaEngineSources(engineName, [
+    "source-engine-3",
+  ]);
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Remove a Source Engine from a Meta Engine
 
 ```javascript
-const engineName = 'my-meta-engine'
+const engineName = "my-meta-engine";
 
-client
-  .deleteMetaEngineSources(engineName, ['source-engine-3'])
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.deleteMetaEngineSources(engineName, [
+    "source-engine-3",
+  ]);
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ##### Creating Engines
 
 ```javascript
-const engineName = 'my-meta-engine'
+const engineName = "favorite-videos";
 
-client
-  .createEngine(engineName, {
-    type: 'meta',
-    source_engines: ['source-engine-1', 'source-engine-2']
-  })
-  .then(response => console.log(response))
-  .catch(error => console.log(error.errorMessages))
+try {
+  const engine = await client.createEngine(engineName, { language: "en" });
+  console.log(engine);
+} catch (e) {
+  console.error(e);
+}
 ```
 
 ### For App Search APIs not available in this client

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install @elastic/app-search-node
 
 ```js
 // CommonJS
-const AppSearchClient = require('@elastic/app-search-node')
+const AppSearchClient = require('@elastic/app-search-node');
 
 // ES6 or a Typescript project *with* `esModuleInterop` enabled
 import AppSearchClient from '@elastic/app-search-node';
@@ -73,7 +73,7 @@ When using the [SaaS version available on swiftype.com](https://app.swiftype.com
 The `hostIdentifier` can be found within the [Credentials](https://app.swiftype.com/as#/credentials) menu.
 
 ```javascript
-const AppSearchClient = require('@elastic/app-search-node')
+const AppSearchClient = require('@elastic/app-search-node');
 const hostIdentifier = "host-c5s2mj";
 const apiKey = "private-mu75psc5egt9ppzuycnc2mc3";
 const client = new AppSearchClient(hostIdentifier, apiKey);

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ To install this package, run:
 npm install @elastic/app-search-node
 ```
 
+## Importing
+
+```js
+// CommonJS
+const AppSearchClient = require('@elastic/app-search-node')
+
+// ES6 or a Typescript project *with* `esModuleInterop` enabled
+import AppSearchClient from '@elastic/app-search-node';
+
+// In a Typescript environment *without* `esModuleInterop` enabled
+import * as AppSearchClient from '@elastic/app-search-node';
+```
+
 ## Versioning
 
 This client is versioned and released alongside App Search.

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -705,3 +705,21 @@ declare module "@elastic/app-search-node" {
     ): void;
   }
 }
+
+declare module "@elastic/app-search-node/lib/client" {
+  export = Client;
+  declare class Client {
+    constructor(apiKey: any, baseUrl: any);
+    apiKey: string;
+    clientName: string;
+    clientVersion: string;
+    baseUrl: string;
+    get(path: string, params: any): Promise<any>;
+    post(path: string, params: any): Promise<any>;
+    put(path: string, params: any): Promise<any>;
+    patch(path: string, params: any): Promise<any>;
+    delete(path: string, params: any): Promise<any>;
+    _jsonRequest(method: any, path: string, params: any): Promise<any>;
+    _wrap(options: any): Promise<any>;
+  }
+}

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -1,0 +1,73 @@
+
+
+declare module "@elastic/app-search-node" {
+  export = AppSearchClient;
+
+  namespace AppSearchClient {
+    export interface SearchResponse {
+      meta: {
+        warnings: string[];
+        page: {
+          total_pages: number;
+          size: number;
+          current: number;
+          total_results: number;
+        };
+        alerts: string[];
+        precision?: number;
+        request_id?: string;
+        engine?: {
+          name: string;
+          type: string;
+        };
+      };
+      results: Record<string, any>[];
+    }
+  }
+
+  class AppSearchClient {
+    /**
+     * @example
+     *
+     * // Typical usage:
+     * const apiKey = 'private-mu75psc5egt9ppzuycnc2mc3'
+     * const baseUrlFn = () => 'http://localhost:3002/api/as/v1/'
+     * const client = new AppSearchClient(undefined, apiKey, baseUrlFn)
+     *
+     * // Deprecated usage for Swiftype.com:
+     * const hostIdentifier = "host-c5s2mj";
+     * const apiKey = "private-mu75psc5egt9ppzuycnc2mc3";
+     * const client = new AppSearchClient(hostIdentifier, apiKey)
+     */
+    constructor(
+      accountHostKey: string | undefined,
+      apiKey: string,
+      baseUrlFn?: (accountHostKey: any) => string
+    );
+
+    /**
+     * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/search.html)
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const query = "cat";
+     * const options = {
+     *   search_fields: { title: {} },
+     *   result_fields: { title: { raw: {} } },
+     * };
+     *
+     * try {
+     *   const response = await client.search('national-parks', '')
+     *   console.log(response.results)
+     * } catch (e) {
+     *   console.error(e)
+     * }
+     */
+    search(
+      engineName: string,
+      query: string,
+      options?: Record<string, any>
+    ): AppSearchClient.SearchResponse;
+  }
+}

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -2,10 +2,13 @@ declare module "@elastic/app-search-node" {
   export = AppSearchClient;
 
   namespace AppSearchClient {
-
     export interface DocumentResponse {
       id: string;
       errors: string[];
+    }
+
+    export interface SingleDocumentResponse {
+      id: string;
     }
     export interface Paging {
       total_pages: number;
@@ -50,6 +53,12 @@ declare module "@elastic/app-search-node" {
 
     export interface DeleteResponse {
       deleted: boolean;
+    }
+
+    export interface DocumentDeleteResponse {
+      deleted: boolean;
+      result: boolean;
+      id: string;
     }
   }
 
@@ -148,67 +157,225 @@ declare module "@elastic/app-search-node" {
      * Create or update a single document
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * const document = {
+     *   id: "INscMGmhmX4",
+     *   url: "https://www.youtube.com/watch?v=INscMGmhmX4",
+     *   title: "The Original Grumpy Cat",
+     *   body: "A wonderful video of a magnificent cat.",
+     * };
+     * 
+     * try {
+     *   const singleDocumentResponse = await client.indexDocument(engineName, document);
+     *   console.log(`Indexed ${singleDocumentResponse.id} succesfully`);
+     * } catch (e) {
+     *   console.log(e);
+     * }
+
      */
-    indexDocument(engineName: string, document: Record<string, any>): Promise<DocumentResponse[]>;
+    indexDocument(
+      engineName: string,
+      document: Record<string, any>
+    ): Promise<AppSearchClient.SingleDocumentResponse>;
 
     /**
      * Create or update documents
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const documents = [
+     *   {
+     *     id: "INscMGmhmX4",
+     *     url: "https://www.youtube.com/watch?v=INscMGmhmX4",
+     *     title: "The Original Grumpy Cat",
+     *     body: "A wonderful video of a magnificent cat.",
+     *   },
+     *   {
+     *     id: "JNDFojsd02",
+     *     url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+     *     title: "Another Grumpy Cat",
+     *     body: "A great video of another cool cat.",
+     *   },
+     * ];
+     *
+     * try {
+     *   const documentResponses = await client.indexDocuments(engineName, document);
+     *   const succesfullyIndexedDocumentIds = documentResponses
+     *     .filter((documentResponse) => documentResponse.errors.length === 0)
+     *     .map((documentResponse) => documentResponse.id)
+     *     .join(", ");
+     *   console.log(
+     *     `Documents indexed successfully: ${succesfullyIndexedDocumentIds}`
+     *   );
+     *
+     *   const failures = documentResponses.filter(
+     *     (documentResponse) => documentResponse.errors.length > 0
+     *   );
+     *   if (failures.length > 0) {
+     *     console.log(
+     *       `Other documents failed with errors: ${failures
+     *         .map((documentResponse) => documentResponse.errors)
+     *         .join(", ")}`
+     *     );
+     *   }
+     * } catch (e) {
+     *   console.log(e);
+     * }
      */
-    indexDocuments(engineName: string, documents: Record<string, any>[]): void;
+    indexDocuments(
+      engineName: string,
+      documents: Record<string, any>[]
+    ): Promise<AppSearchClient.DocumentResponse[]>;
 
     /**
      * Update specific document fields by id and field
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     *
+     * @example
+     * const engineName = "favorite-videos";
+     * const documents = [
+     *   {
+     *     id: "INscMGmhmX4",
+     *     title: "Updated title",
+     *   },
+     *   {
+     *     id: "JNDFojsd02",
+     *     title: "Updated title",
+     *   },
+     * ];
+     *
+     * try {
+     *   const documentResponses = await client.updateDocuments(engineName, document);
+     *   const succesfullyIndexedDocumentIds = documentResponses
+     *     .filter((documentResponse) => documentResponse.errors.length === 0)
+     *     .map((documentResponse) => documentResponse.id)
+     *     .join(", ");
+     *   console.log(
+     *     `Documents updated successfully: ${succesfullyIndexedDocumentIds}`
+     *   );
+     *
+     *   const failures = documentResponses.filter(
+     *     (documentResponse) => documentResponse.errors.length > 0
+     *   );
+     *   if (failures.length > 0) {
+     *     console.log(
+     *       `Other documents failed with errors: ${failures
+     *         .map((documentResponse) => documentResponse.errors)
+     *         .join(", ")}`
+     *     );
+     *   }
+     * } catch (e) {
+     *   console.log(e);
+     * }
      */
-    updateDocuments(engineName: string, documents: Record<string, any>[]): void;
+    updateDocuments(
+      engineName: string,
+      documents: Record<string, any>[]
+    ): Promise<AppSearchClient.DocumentResponse[]>;
 
     /**
      * Lists up to 10,000 documents
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-list
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     *
+     * try {
+     *   const documentList = await client.listDocuments(engineName, {
+     *     page: { size: 10, current: 1 },
+     *   });
+     *   documentList.results.forEach((r) => console.log(r));
+     * } catch (e) {
+     *   console.error(e);
+     * }
      */
-    listDocuments(engineName: string, options?: Record<string, any>): void;
+    listDocuments(
+      engineName: string,
+      options?: Record<string, any>
+    ): Promise<AppSearchClient.PagedResponse>;
 
     /**
      * Retrieves one or more documents by id
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-get
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const documentIds = ["INscMGmhmX4", "JNDFojsd02"];
+     *
+     * try {
+     *   const documents = await client.getDocuments(engineName, documentIds);
+     *   // documents that are not found return as null
+     *   console.log(documents.filter((document) => document !== null));
+     * } catch (e) {
+     *   console.error(e);
+     * }
      */
-    getDocuments(engineName: string, ids: string[]): void;
+    getDocuments(
+      engineName: string,
+      ids: string[]
+    ): Promise<Array<Record<string, any> | null>>;
 
     /**
      * Deletes documents for given Document IDs
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-delete
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const documentIds = ["INscMGmhmX4", "JNDFojsd02"];
+     *
+     * try {
+     *   const response = await client.destroyDocuments(engineName, documentIds);
+     *   const deltedIds = response.filter((r) => r.deleted === true).map((r) => r.id);
+     *   console.log(`Deleted documents ${deltedIds.join(", ")}`);
+     * } catch (e) {
+     *   console.error(e);
+     * }
      */
-    destroyDocuments(engineName: string, ids: string[]): void;
+    destroyDocuments(
+      engineName: string,
+      ids: string[]
+    ): Promise<AppSearchClient.DocumentDeleteResponse[]>;
 
     /**
      * Retrieves all engines with optional pagination support
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-list
-     * 
+     *
      * @example
-     * 
+     *
      * try {
      *   const engines = await client.listEngines({ page: { size: 10, current: 1 } });
-     *   console.log(engines);
+     *   engines.results.forEach(r => console.log(r));
      * } catch (e) {
      *   console.error(e);
      * }
      */
-    listEngines(options?: Record<string, any>): Promise<AppSearchClient.PagedResponse>;
+    listEngines(
+      options?: Record<string, any>
+    ): Promise<AppSearchClient.PagedResponse>;
 
     /**
      * Retrieves details of a given engine by its name
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-get
-     * 
+     *
      * @example
-     * 
+     *
      * const engineName = "favorite-videos";
-     * 
+     *
      * try {
      *   const engine = await client.getEngine(engineName);
      *   console.log(engine);
@@ -222,11 +389,11 @@ declare module "@elastic/app-search-node" {
      * Creates an App Search Engine
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-create
-     * 
+     *
      * @example
-     * 
+     *
      * const engineName = "favorite-videos";
-     * 
+     *
      * try {
      *   const engine = await client.createEngine(engineName, { language: "en" });
      *   console.log(engine);
@@ -234,17 +401,20 @@ declare module "@elastic/app-search-node" {
      *   console.error(e);
      * }
      */
-    createEngine(engineName: string, options?: Record<string, any>): Promise<Record<string, any>>;
+    createEngine(
+      engineName: string,
+      options?: Record<string, any>
+    ): Promise<Record<string, any>>;
 
     /**
      * Deletes a source engine from a given meta engine
      *
      * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
-     * 
+     *
      * @example
-     * 
+     *
      * const engineName = "favorite-videos";
-     * 
+     *
      * try {
      *   const response = await client.destroyEngine(engineName);
      *   console.log(response);
@@ -252,22 +422,22 @@ declare module "@elastic/app-search-node" {
      *   console.error(e);
      * }
      */
-    destroyEngine(engineName: string): Promise<DeleteResponse>;
+    destroyEngine(engineName: string): Promise<AppSearchClient.DeleteResponse>;
 
     /**
      * Retrieve available curations for the given engine
-     * 
+     *
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
-     * 
+     *
      * @example
-     * 
+     *
      * const engineName = "favorite-videos";
-     * 
+     *
      * try {
      *   const curationsList = await client.listCurations(engineName, {
      *     page: { size: 10, current: 1 },
      *   });
-     *   curationsList.results.forEach(console.log);
+     *   curationsList.results.forEach(r => console.log(r));
      * } catch (e) {
      *   console.error(e);
      * }

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -2,15 +2,21 @@ declare module "@elastic/app-search-node" {
   export = AppSearchClient;
 
   namespace AppSearchClient {
+
+    export interface DocumentResponse {
+      id: string;
+      errors: string[];
+    }
+    export interface Paging {
+      total_pages: number;
+      size: number;
+      current: number;
+      total_results: number;
+    }
     export interface SearchResponse {
       meta: {
         warnings: string[];
-        page: {
-          total_pages: number;
-          size: number;
-          current: number;
-          total_results: number;
-        };
+        page: Paging;
         alerts: string[];
         precision?: number;
         request_id?: string;
@@ -20,6 +26,30 @@ declare module "@elastic/app-search-node" {
         };
       };
       results: Record<string, any>[];
+    }
+
+    export interface PagedResponse {
+      meta: {
+        page: Paging;
+      };
+      results: Record<string, any>[];
+    }
+
+    export interface QuerySuggestionsResponse {
+      meta: {
+        request_id: string;
+      };
+      results: {
+        documents: QuerySuggestion[];
+      };
+    }
+
+    export interface QuerySuggestion {
+      suggestion: string;
+    }
+
+    export interface DeleteResponse {
+      deleted: boolean;
     }
   }
 
@@ -45,7 +75,7 @@ declare module "@elastic/app-search-node" {
 
     /**
      * Submit a search and receive a set of results with meta data
-     * 
+     *
      * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/search.html)
      *
      * @example
@@ -72,7 +102,7 @@ declare module "@elastic/app-search-node" {
 
     /**
      * Run multiple searches for documents on a single request
-     * 
+     *
      * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/multi-search.html)
      *
      * @example
@@ -100,5 +130,407 @@ declare module "@elastic/app-search-node" {
       engineName: string,
       searches: { query: string; options?: Record<string, any> }[]
     ): Promise<AppSearchClient.SearchResponse[]>;
+
+    /**
+     * Provide relevant query suggestions for incomplete queries
+     *
+     * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/query-suggestion.html)
+     *
+     *
+     */
+    querySuggestion(
+      engineName: string,
+      query: string,
+      options?: Record<string, any>
+    ): Promise<AppSearchClient.QuerySuggestionsResponse>;
+
+    /**
+     * Create or update a single document
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     */
+    indexDocument(engineName: string, document: Record<string, any>): Promise<DocumentResponse[]>;
+
+    /**
+     * Create or update documents
+     */
+    indexDocuments(engineName: string, documents: Record<string, any>[]): void;
+
+    /**
+     * Update specific document fields by id and field
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     */
+    updateDocuments(engineName: string, documents: Record<string, any>[]): void;
+
+    /**
+     * Lists up to 10,000 documents
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-list
+     */
+    listDocuments(engineName: string, options?: Record<string, any>): void;
+
+    /**
+     * Retrieves one or more documents by id
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-get
+     */
+    getDocuments(engineName: string, ids: string[]): void;
+
+    /**
+     * Deletes documents for given Document IDs
+     *
+     * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-delete
+     */
+    destroyDocuments(engineName: string, ids: string[]): void;
+
+    /**
+     * Retrieves all engines with optional pagination support
+     *
+     * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-list
+     * 
+     * @example
+     * 
+     * try {
+     *   const engines = await client.listEngines({ page: { size: 10, current: 1 } });
+     *   console.log(engines);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    listEngines(options?: Record<string, any>): Promise<AppSearchClient.PagedResponse>;
+
+    /**
+     * Retrieves details of a given engine by its name
+     *
+     * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-get
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * 
+     * try {
+     *   const engine = await client.getEngine(engineName);
+     *   console.log(engine);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    getEngine(engineName: string): Promise<Record<string, any>>;
+
+    /**
+     * Creates an App Search Engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-create
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * 
+     * try {
+     *   const engine = await client.createEngine(engineName, { language: "en" });
+     *   console.log(engine);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    createEngine(engineName: string, options?: Record<string, any>): Promise<Record<string, any>>;
+
+    /**
+     * Deletes a source engine from a given meta engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * 
+     * try {
+     *   const response = await client.destroyEngine(engineName);
+     *   console.log(response);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    destroyEngine(engineName: string): Promise<DeleteResponse>;
+
+    /**
+     * Retrieve available curations for the given engine
+     * 
+     * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * 
+     * try {
+     *   const curationsList = await client.listCurations(engineName, {
+     *     page: { size: 10, current: 1 },
+     *   });
+     *   curationsList.results.forEach(console.log);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    listCurations(
+      engineName: string,
+      options?: Record<string, any>
+    ): Promise<AppSearchClient.PagedResponse>;
+
+    /**
+     * Retrieves a curation by ID
+     *
+     * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const curationId = "cur-7438290";
+     *
+     * try {
+     *   const curation = await client.getCuration(engineName, curationId);
+     *   console.log(curation);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    getCuration(
+      engineName: string,
+      curationId: string
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Create a new curation for the engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-create
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const newCuration = {
+     *   queries: ["cat blop"],
+     *   promoted: ["Jdas78932"],
+     * };
+     *
+     * try {
+     *   const curation = await client.createCuration(engineName, newCuration);
+     *   console.log(curation);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     *
+     */
+    createCuration(
+      engineName: string,
+      newCuration: Record<string, any>
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Updates an existing curation 
+     * 
+     * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-update
+     * 
+     * const engineName = "favorite-videos";
+     * const curationId = "cur-7438290";
+     * const newDetails = {
+     *   queries: ["cat blop"],
+     *   promoted: ["Jdas78932", "JFayf782"],
+     * };
+
+     * try {
+     *   const curation = await client.updateCuration(
+     *     engineName,
+     *     curationId,
+     *     newDetails
+     *   );
+     *   console.log(curation);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    updateCuration(
+      engineName: string,
+      curationId: string,
+      newCuration: Record<string, any>
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Deletes a curation set by ID
+     *
+     * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-destroy
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const curationId = "cur-7438290";
+     *
+     * try {
+     *   const response = await client.destroyCuration(engineName, curationId);
+     *   console.log(response.deleted);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    destroyCuration(
+      engineName: string,
+      curationId: string
+    ): Promise<AppSearchClient.DeleteResponse>;
+
+    /**
+     * Creates a new meta engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/engines.html
+     * https://www.elastic.co/guide/en/app-search/current/meta-engines-guide.html
+     *
+     * @example
+     *
+     * const engineName = "my-meta-engine";
+     *
+     * try {
+     *   const engine = await client.createMetaEngine(engineName, [
+     *     "source-engine-1",
+     *     "source-engine-2",
+     *   ]);
+     *   console.log(engine);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    createMetaEngine(
+      engineName: string,
+      sourceEngines: string[]
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Adds a source engine to a given meta engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-add-source-engines
+     *
+     * @example
+     *
+     * const engineName = "my-meta-engine";
+     *
+     * try {
+     *   const engine = await client.addMetaEngineSources(engineName, [
+     *     "source-engine-3",
+     *   ]);
+     *   console.log(engine);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    addMetaEngineSources(
+      engineName: string,
+      sourceEngines: string[]
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Deletes a source engine from a given meta engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
+     *
+     * @example
+     *
+     * const engineName = "my-meta-engine";
+     *
+     * try {
+     *   const engine = await client.deleteMetaEngineSources(engineName, [
+     *     "source-engine-3",
+     *   ]);
+     *   console.log(engine);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    deleteMetaEngineSources(
+      engineName: string,
+      sourceEngines: string[]
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Retrieve current schema for the engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/schema.html#schema-read
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     *
+     * try {
+     * const schema = await client.getSchema(engineName);
+     *   console.log(schema);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    getSchema(engineName: string): Promise<Record<string, any>>;
+
+    /**
+     * Update schema for the current engine
+     *
+     * https://www.elastic.co/guide/en/app-search/current/schema.html#schema-patch
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const schema = {
+     *   views: "number",
+     *   created_at: "date",
+     * };
+     *
+     * try {
+     *   const updatedSchema = await client.updateSchema(engineName, schema);
+     *   console.log(updatedSchema);
+     * } catch (e) {
+     *   console.error(e);
+     * }
+     */
+    updateSchema(
+      engineName: string,
+      schema: Record<string, any>
+    ): Promise<Record<string, any>>;
+
+    /**
+     * Creates a jwt search key that can be used for authentication to enforce a set of required search options.
+     * 
+     * More details can be found [here](https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-signed).
+     *
+     * @param apiKey A public search key for your App Search Engine
+     * @param apiKeyName This name must match the name of the key above from your App Search dashboard
+     * @param options see the [App Search API](https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-signed) for supported search options
+     * @param signOptions see [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken#usage) for supported sign options
+     * 
+     * @example
+     * 
+     * const publicSearchKey = 'search-xxxxxxxxxxxxxxxxxxxxxxxx'
+     * // This name must match the name of the key above from your App Search dashboard
+     * const publicSearchKeyName = 'search-key'
+     * const enforcedOptions = {
+     *   result_fields: { title: { raw: {} } },
+     *   filters: { world_heritage_site: 'true' }
+     * }
+
+     * const signOptions = {
+     *   expiresIn: '5 minutes'
+     * }
+
+     * const signedSearchKey = AppSearchClient.createSignedSearchKey(
+     *   publicSearchKey,
+     *   publicSearchKeyName,
+     *   enforcedOptions,
+     *   signOptions
+     * )
+
+     * const baseUrlFn = () => 'http://localhost:3002/api/as/v1/'
+     * const client = new AppSearchClient(undefined, signedSearchKey, baseUrlFn)
+
+     * client.search('sample-engine', 'everglade')
+     */
+    static createSignedSearchKey(
+      apiKey: string,
+      apiKeyName: string,
+      options?: Record<string, any>,
+      signOptions?: Record<string, any>
+    ): void;
   }
 }

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -172,7 +172,7 @@ declare module "@elastic/app-search-node" {
      *   const singleDocumentResponse = await client.indexDocument(engineName, document);
      *   console.log(`Indexed ${singleDocumentResponse.id} succesfully`);
      * } catch (e) {
-     *   console.log(e);
+     *   console.error(e);
      * }
      */
     indexDocument(
@@ -224,7 +224,7 @@ declare module "@elastic/app-search-node" {
      *     );
      *   }
      * } catch (e) {
-     *   console.log(e);
+     *   console.error(e);
      * }
      */
     indexDocuments(
@@ -271,7 +271,7 @@ declare module "@elastic/app-search-node" {
      *     );
      *   }
      * } catch (e) {
-     *   console.log(e);
+     *   console.error(e);
      * }
      */
     updateDocuments(

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -87,6 +87,10 @@ declare module "@elastic/app-search-node" {
      *
      * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/search.html)
      *
+     * @param engineName unique Engine name
+     * @param query String that is used to perform a search request.
+     * @param options See elastic.co documentation for supported options.
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -102,7 +106,9 @@ declare module "@elastic/app-search-node" {
      * } catch (e) {
      *   console.error(e);
      * }
+     * 
      */
+    
     search(
       engineName: string,
       query: string,
@@ -112,8 +118,11 @@ declare module "@elastic/app-search-node" {
     /**
      * Run multiple searches for documents on a single request
      *
-     * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/multi-search.html)
-     *
+     * https://www.elastic.co/guide/en/app-search/current/multi-search.html
+     * 
+     * @param engineName unique Engine name
+     * @param searches Searches to execute
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -145,7 +154,28 @@ declare module "@elastic/app-search-node" {
      *
      * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/query-suggestion.html)
      *
-     *
+     * @param engineName unique Engine name
+     * @param query String that is used to perform a query suggestion request.
+     * @param options See elastic.co documentation for supported options.
+     * 
+     * @example
+     * 
+     * const engineName = "favorite-videos";
+     * const document = {
+     *   id: "INscMGmhmX4",
+     *   url: "https://www.youtube.com/watch?v=INscMGmhmX4",
+     *   title: "The Original Grumpy Cat",
+     *   body: "A wonderful video of a magnificent cat.",
+     * };
+     * try {
+     *   const singleDocumentResponse = await client.indexDocument(
+     *     engineName,
+     *     document
+     *   );
+     *   console.log(`Indexed ${singleDocumentResponse.id} succesfully`);
+     * } catch (e) {
+     *   console.error(e);
+     * }
      */
     querySuggestion(
       engineName: string,
@@ -157,6 +187,9 @@ declare module "@elastic/app-search-node" {
      * Create or update a single document
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
+     * 
+     * @param engineName unique Engine name
+     * @param document document object to be indexed.
      * 
      * @example
      * 
@@ -185,6 +218,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
      *
+     * @param engineName unique Engine name
+     * @param documents Array of document objects to be indexed.
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -237,7 +273,11 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
      *
+     * @param engineName unique Engine name
+     * @param documents Array of document objects to be updated.
+     * 
      * @example
+     * 
      * const engineName = "favorite-videos";
      * const documents = [
      *   {
@@ -284,6 +324,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-list
      *
+     * @param engineName unique Engine name
+     * @param options See elastic.co documentation for supported options.
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -307,6 +350,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-get
      *
+     * @param engineName unique Engine name
+     * @param ids Array of document ids to be retrieved
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -330,6 +376,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/documents.html#documents-delete
      *
+     * @param {String} engineName unique Engine name
+     * @param {Array<String>} ids Array of document ids to be destroyed
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -353,6 +402,8 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-list
      *
+     * @param options See elastic.co documentation for supported options.
+     * 
      * @example
      *
      * try {
@@ -371,6 +422,8 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-get
      *
+     * @param engineName unique Engine name
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -389,6 +442,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/engines.html#engines-create
      *
+     * @param engineName unique Engine name
+     * @param options See elastic.co documentation for supported options.
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -410,6 +466,8 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
      *
+     * @param engineName unique Engine name
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -428,6 +486,8 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
      *
+     * @param engineName unique Engine name
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -451,6 +511,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
      *
+     * @param engineName unique Engine name
+     * @param curationId unique Curation id
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -473,6 +536,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-create
      *
+     * @param engineName unique Engine name
+     * @param newCuration body of the Curation object
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -498,6 +564,10 @@ declare module "@elastic/app-search-node" {
      * Updates an existing curation 
      * 
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-update
+     * 
+     * @param engineName unique Engine name
+     * @param curationId unique Curation id
+     * @param newCuration body of the Curation object
      * 
      * @example
      * 
@@ -529,6 +599,9 @@ declare module "@elastic/app-search-node" {
      * Deletes a curation set by ID
      *
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-destroy
+     * 
+     * @param engineName unique Engine name
+     * @param curationId unique Curation name
      *
      * @example
      *
@@ -553,6 +626,9 @@ declare module "@elastic/app-search-node" {
      * https://www.elastic.co/guide/en/app-search/current/engines.html
      * https://www.elastic.co/guide/en/app-search/current/meta-engines-guide.html
      *
+     * @param engineName unique Engine name
+     * @param sourceEngines list of engine names to use as source engines
+     * 
      * @example
      *
      * const engineName = "my-meta-engine";
@@ -577,6 +653,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-add-source-engines
      *
+     * @param engineName Name of Meta Engine
+     * @param sourceEngines Names of Engines to use as Source Engines
+     * 
      * @example
      *
      * const engineName = "my-meta-engine";
@@ -599,6 +678,9 @@ declare module "@elastic/app-search-node" {
      * Deletes a source engine from a given meta engine
      *
      * https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
+     * 
+     * @param engineName Name of Meta Engine
+     * @param sourceEngines Names of existing Source Engines to remove
      *
      * @example
      *
@@ -623,6 +705,8 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/schema.html#schema-read
      *
+     * @param engineName unique Engine name
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -641,6 +725,9 @@ declare module "@elastic/app-search-node" {
      *
      * https://www.elastic.co/guide/en/app-search/current/schema.html#schema-patch
      *
+     * @param engineName unique Engine name
+     * @param schema body of schema object
+     * 
      * @example
      *
      * const engineName = "favorite-videos";
@@ -708,7 +795,7 @@ declare module "@elastic/app-search-node" {
 
 declare module "@elastic/app-search-node/lib/client" {
   export = Client;
-  declare class Client {
+  class Client {
     constructor(apiKey: any, baseUrl: any);
     apiKey: string;
     clientName: string;

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -174,7 +174,6 @@ declare module "@elastic/app-search-node" {
      * } catch (e) {
      *   console.log(e);
      * }
-
      */
     indexDocument(
       engineName: string,
@@ -499,6 +498,8 @@ declare module "@elastic/app-search-node" {
      * Updates an existing curation 
      * 
      * https://www.elastic.co/guide/en/app-search/current/curations.html#curations-update
+     * 
+     * @example
      * 
      * const engineName = "favorite-videos";
      * const curationId = "cur-7438290";

--- a/app-search-node.d.ts
+++ b/app-search-node.d.ts
@@ -1,5 +1,3 @@
-
-
 declare module "@elastic/app-search-node" {
   export = AppSearchClient;
 
@@ -46,6 +44,8 @@ declare module "@elastic/app-search-node" {
     );
 
     /**
+     * Submit a search and receive a set of results with meta data
+     * 
      * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/search.html)
      *
      * @example
@@ -58,16 +58,47 @@ declare module "@elastic/app-search-node" {
      * };
      *
      * try {
-     *   const response = await client.search('national-parks', '')
-     *   console.log(response.results)
+     *   const response = await client.search(engineName, query);
+     *   console.log(response.results);
      * } catch (e) {
-     *   console.error(e)
+     *   console.error(e);
      * }
      */
     search(
       engineName: string,
       query: string,
       options?: Record<string, any>
-    ): AppSearchClient.SearchResponse;
+    ): Promise<AppSearchClient.SearchResponse>;
+
+    /**
+     * Run multiple searches for documents on a single request
+     * 
+     * `options` are documented [here](https://www.elastic.co/guide/en/app-search/current/multi-search.html)
+     *
+     * @example
+     *
+     * const engineName = "favorite-videos";
+     * const searches = [
+     *   {
+     *     query: "cat",
+     *     options: {
+     *       search_fields: { title: {} },
+     *       result_fields: { title: { raw: {} } },
+     *     },
+     *   },
+     *   { query: "grumpy" },
+     * ];
+     *
+     * try {
+     *   const responses = await client.multiSearch(engineName, query);
+     *   console.log(responses);
+     * } catch (e) {
+     *   console.error(e)
+     * }
+     */
+    multiSearch(
+      engineName: string,
+      searches: { query: string; options?: Record<string, any> }[]
+    ): Promise<AppSearchClient.SearchResponse[]>;
   }
 }

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"},{\"id\":\"JNDFojsd02\",\"url\":\"http://www.youtube.com/watch?v=tsdfhk2j\",\"title\":\"Another Grumpy Cat\",\"body\":\"this is also a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"},{\"id\":\"JNDFojsd02\",\"url\":\"http://www.youtube.com/watch?v=tsdfhk2j\",\"title\":\"Another Grumpy Cat\",\"body\":\"this is also a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15193573244029391
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"},{\"id\":\"JNDFojsd02\",\"url\":\"http://www.youtube.com/watch?v=tsdfhk2j\",\"title\":\"Another Grumpy Cat\",\"body\":\"this is also a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"JNDFojsd02\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"JNDFojsd02\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732448113219
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"JNDFojsd02\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"FakeId\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"FakeId\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732459996374
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [\"INscMGmhmX4\",\"FakeId\"]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/search
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"query\":\"cat\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/search
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"query\":\"cat\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/151935732470971687
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example/search
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"query\":\"cat\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/15208899348639621
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/swiftype-api-example/documents
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: [{\"id\":\"INscMGmhmX4\",\"url\":\"http://www.youtube.com/watch?v=v1uyQZNg2vE\",\"title\":\"The Original Grumpy Cat\",\"body\":\"this is a test\"}]

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
@@ -2,7 +2,7 @@ GET /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 
 HTTP/1.1 200 OK

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
@@ -2,7 +2,7 @@ GET /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 
 HTTP/1.1 200 OK

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643363747751014
@@ -2,7 +2,7 @@ GET /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 
 HTTP/1.1 200 OK

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643460487616422
@@ -2,7 +2,7 @@ GET /api/as/v1/engines/swiftype-api-example
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
@@ -2,7 +2,7 @@ POST /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"name\":\"new-engine\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
@@ -2,7 +2,7 @@ POST /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"name\":\"new-engine\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643531437267705
@@ -2,7 +2,7 @@ POST /api/as/v1/engines
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {\"name\":\"new-engine\"}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/new-engine
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/new-engine
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152643588771342928
@@ -2,7 +2,7 @@ DELETE /api/as/v1/engines/new-engine
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
@@ -2,7 +2,7 @@ GET /api/as/v1/engines?page[current]=2&page[size]=1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
@@ -2,7 +2,7 @@ GET /api/as/v1/engines?page[current]=2&page[size]=1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/152666640463285327
@@ -2,7 +2,7 @@ GET /api/as/v1/engines?page[current]=2&page[size]=1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
 accept: application/json
 body: {}

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139235186519
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations?page[current]=2&page[size]=1
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations?page[current]=2&page[size]=1
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775139267473451
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations?page[current]=2&page[size]=1
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775207819050958
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775369860896529
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/curations
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/swiftype-api-example/curations/cur-378291
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/swiftype-api-example/curations/cur-378291
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775388696063661
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/swiftype-api-example/curations/cur-378291
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
@@ -1,6 +1,6 @@
 PUT /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
@@ -1,6 +1,6 @@
 PUT /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775411564681581
@@ -1,6 +1,6 @@
 PUT /api/as/v1/engines/swiftype-api-example/curations/cur-9382
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-0000
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-0000
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154775710380210466
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/curations/cur-0000
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154844848285366145
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905605865969485
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/154905668608952844
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/query_suggestion
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158153945918596904
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/documents/list
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/documents/list
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646044979291659
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/documents/list
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
@@ -1,6 +1,6 @@
 PATCH /api/as/v1/engines/swiftype-api-example/documents
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
@@ -1,6 +1,6 @@
 PATCH /api/as/v1/engines/swiftype-api-example/documents
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/158646109175536388
@@ -1,6 +1,6 @@
 PATCH /api/as/v1/engines/swiftype-api-example/documents
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/401
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/401
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer invalid

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/401
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/401
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer invalid

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/401
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/401
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer invalid

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/404
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/404
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/invalid-engine-name/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/404
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/404
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/invalid-engine-name/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/404
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/404
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/invalid-engine-name/search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
+++ b/fixtures/host-c5s2mj.api.swiftype.com-443/multiSearchErrors
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/multi_search
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: host-c5s2mj.api.swiftype.com
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/15815391173475749
+++ b/fixtures/localhost-3002/15815391173475749
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/15815391173475749
+++ b/fixtures/localhost-3002/15815391173475749
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
@@ -11,7 +11,7 @@ HTTP/1.1 200 OK
 x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
-x-app-search-version: 7.15.0
+x-app-search-version: 7.15.1-beta.0
 content-type: application/json; charset=utf-8
 vary: Origin
 etag: W/"cdb1493c20f29d2310c3222758a6c07b"

--- a/fixtures/localhost-3002/15815391173475749
+++ b/fixtures/localhost-3002/15815391173475749
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/15815978342879229
+++ b/fixtures/localhost-3002/15815978342879229
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
@@ -11,7 +11,7 @@ HTTP/1.1 200 OK
 x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
-x-app-search-version: 7.15.0
+x-app-search-version: 7.15.1-beta.0
 content-type: application/json; charset=utf-8
 vary: Origin
 etag: W/"3d866b390e18c1bf51503b81707dc011"

--- a/fixtures/localhost-3002/15815978342879229
+++ b/fixtures/localhost-3002/15815978342879229
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/15815978342879229
+++ b/fixtures/localhost-3002/15815978342879229
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/158159799829857287
+++ b/fixtures/localhost-3002/158159799829857287
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
@@ -11,7 +11,7 @@ HTTP/1.1 200 OK
 x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
-x-app-search-version: 7.15.0
+x-app-search-version: 7.15.1-beta.0
 content-type: application/json; charset=utf-8
 vary: Origin
 etag: W/"cdb1493c20f29d2310c3222758a6c07b"

--- a/fixtures/localhost-3002/158159799829857287
+++ b/fixtures/localhost-3002/158159799829857287
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/158159799829857287
+++ b/fixtures/localhost-3002/158159799829857287
@@ -1,6 +1,6 @@
 DELETE /api/as/v1/engines/new-meta-engine/source_engines
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/get-schema
+++ b/fixtures/localhost-3002/get-schema
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/get-schema
+++ b/fixtures/localhost-3002/get-schema
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
@@ -11,7 +11,7 @@ HTTP/1.1 200 OK
 x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
-x-app-search-version: 7.15.0
+x-app-search-version: 7.15.1-beta.0
 content-type: application/json; charset=utf-8
 vary: Origin
 etag: W/"ac828da6380c08d10df2df85cf73c250"

--- a/fixtures/localhost-3002/get-schema
+++ b/fixtures/localhost-3002/get-schema
@@ -1,6 +1,6 @@
 GET /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/update-schema
+++ b/fixtures/localhost-3002/update-schema
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.1-beta.0
+x-swiftype-client-version: 7.16.1-beta.1
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/update-schema
+++ b/fixtures/localhost-3002/update-schema
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.16.0
+x-swiftype-client-version: 7.16.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3

--- a/fixtures/localhost-3002/update-schema
+++ b/fixtures/localhost-3002/update-schema
@@ -1,6 +1,6 @@
 POST /api/as/v1/engines/swiftype-api-example/schema
 x-swiftype-client: elastic-app-search-node
-x-swiftype-client-version: 7.15.0
+x-swiftype-client-version: 7.15.1-beta.0
 content-type: application/json
 host: localhost:3002
 authorization: Bearer api-mu75psc5egt9ppzuycnc2mc3
@@ -11,7 +11,7 @@ HTTP/1.1 200 OK
 x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
-x-app-search-version: 7.15.0
+x-app-search-version: 7.15.1-beta.0
 content-type: application/json; charset=utf-8
 vary: Origin
 etag: W/"5669e9ad4cde52b649ba90479fff9e1f"

--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -58,13 +58,6 @@ class AppSearchClient {
     })
   }
 
-  /**
-   * Sends a query suggestion request to the App Search Api
-   *
-   * @param {String} engineName unique Engine name
-   * @param {String} query String that is used to perform a query suggestion request.
-   * @param {Object} options Object used for configuring the request
-   */
   querySuggestion(engineName, query, options = {}) {
     options = Object.assign({}, options, { query })
     return this.client.post(`engines/${encodeURIComponent(engineName)}/query_suggestion`, options)

--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -43,15 +43,6 @@ class AppSearchClient {
     this.client = new Client(apiKey, baseUrl)
   }
 
-  /**
-   * Send a search request to the App Search Api
-   * https://swiftype.com/documentation/app-search/api/overview
-   *
-   * @param {String} engineName unique Engine name
-   * @param {String} query String that is used to perform a search request.
-   * @param {Object} options Object used for configuring the search like search_fields and result_fields
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   search(engineName, query, options = {}) {
     options = Object.assign({}, options, { query })
     return this.client.get(`engines/${encodeURIComponent(engineName)}/search`, options)

--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -48,13 +48,6 @@ class AppSearchClient {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/search`, options)
   }
 
-  /**
-   * Run multiple searches for documents on a single request
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array} searches Searches to execute, [{query: String, options: Object}]
-   * @returns {Promise<Object>} a Promise that returns an array of results {Object} when resolved, otherwise throws an Error.
-   */
   multiSearch(engineName, searches) {
     searches = searches.map(search => {
       return Object.assign({}, search.options, { query: search.query })

--- a/lib/appSearch.js
+++ b/lib/appSearch.js
@@ -63,13 +63,6 @@ class AppSearchClient {
     return this.client.post(`engines/${encodeURIComponent(engineName)}/query_suggestion`, options)
   }
 
-  /**
-   * Index a document.
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Object} document document object to be indexed.
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   indexDocument(engineName, document) {
     return this.indexDocuments(engineName, [document])
       .then((processedDocumentResults) => {
@@ -86,35 +79,14 @@ class AppSearchClient {
       })
   }
 
-  /**
-   * Index a batch of documents.
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array<Object>} documents Array of document objects to be indexed.
-   * @returns {Promise<Array<Object>>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   indexDocuments(engineName, documents) {
     return this.client.post(`engines/${encodeURIComponent(engineName)}/documents`, documents)
   }
 
-  /**
-   * Partial update a batch of documents.
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array<Object>} documents Array of document objects to be updated.
-   * @returns {Promise<Array<Object>>} a Promise that returns an array of status objects, otherwise throws an Error.
-   */
   updateDocuments(engineName, documents) {
     return this.client.patch(`engines/${encodeURIComponent(engineName)}/documents`, documents)
   }
 
-  /**
-   * List all documents
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Object} options see the <a href="https://swiftype.com/documentation/app-search/api/documents#list">App Search API</a> for supported search options
-   * @returns {Promise<Array<Object>>} a Promise that returns an array of documents, otherwise throws an Error.
-   */
   listDocuments(engineName, options = {}) {
     const pagingParams = buildPagingParams(options.page || {})
     const prefix = pagingParams.length ? '?' : ''
@@ -122,24 +94,10 @@ class AppSearchClient {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/documents/list${prefix}${pagingParams.join('&')}`, {})
   }
 
-  /**
-   * Retrieve a batch of documents.
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array<String>} ids Array of document ids to be retrieved
-   * @returns {Promise<Array<Object>>} a Promise that returns an array of documents, otherwise throws an Error.
-   */
   getDocuments(engineName, ids) {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/documents`, ids)
   }
 
-  /**
-   * Destroy a batch of documents.
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array<String>} ids Array of document ids to be destroyed
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error. Includes "result" keys to maintain backward compatibility.
-   */
   destroyDocuments(engineName, ids) {
     return this.client.delete(`engines/${encodeURIComponent(engineName)}/documents`, ids)
     .then((response) => {
@@ -150,12 +108,6 @@ class AppSearchClient {
       })
   }
 
-
-  /**
-   * List all engines
-   *
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   listEngines(options = {}) {
     const pagingParams = buildPagingParams(options.page || {})
     const prefix = pagingParams.length ? '?' : ''
@@ -163,23 +115,10 @@ class AppSearchClient {
     return this.client.get(`engines${prefix}${pagingParams.join('&')}`, {})
   }
 
-  /**
-   * Retrieve an engine by name
-   *
-   * @param {String} engineName unique Engine name
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   getEngine(engineName) {
     return this.client.get(`engines/${encodeURIComponent(engineName)}`, {})
   }
 
-  /**
-   * Create a new engine
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Object} options
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   createEngine(engineName, options) {
     return this.client.post(`engines`, {
       name: engineName,
@@ -187,45 +126,18 @@ class AppSearchClient {
     })
   }
 
-  /**
-   * Add a Source Engine to a Meta Engine
-   *
-   * @param {String} engineName Name of Meta Engine
-   * @param {Array[String]} sourceEngines Names of Engines to use as Source Engines
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   addMetaEngineSources(engineName, sourceEngines) {
     return this.client.post(`engines/${engineName}/source_engines`, sourceEngines)
   }
 
-  /**
-   * Remove a Source Engine from a Meta Engine
-   *
-   * @param {String} engineName Name of Meta Engine
-   * @param {Array[String]} sourceEngines Names of existing Source Engines to remove
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   deleteMetaEngineSources(engineName, sourceEngines) {
     return this.client.delete(`engines/${engineName}/source_engines`, sourceEngines)
   }
 
-  /**
-   * Delete an engine
-   *
-   * @param {String} engineName unique Engine name
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   destroyEngine(engineName) {
     return this.client.delete(`engines/${encodeURIComponent(engineName)}`, {})
   }
 
-
-  /**
-   * List all Curations
-   *
-   * @param {String} engineName unique Engine name
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   listCurations(engineName, options = {}) {
     const pagingParams = buildPagingParams(options.page || {});
     const prefix = pagingParams.length ? '?' : '';
@@ -233,48 +145,18 @@ class AppSearchClient {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/curations${prefix}${pagingParams.join('&')}`, {})
   }
 
-  /**
-   * Retrieve a Curation by id
-   *
-   * @param {String} engineName unique Engine name
-   * @param {String} curationId unique Curation id
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   getCuration(engineName, curationId) {
-
     return this.client.get(`engines/${encodeURIComponent(engineName)}/curations/${encodeURIComponent(curationId)}`, {})
   }
 
-  /**
-   * Create a new Curation
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Object} newCuration body of the Curation object
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   createCuration(engineName, newCuration) {
     return this.client.post(`engines/${encodeURIComponent(engineName)}/curations`, newCuration)
   }
 
-  /**
-   * Update an existing curation
-   *
-   * @param {String} engineName unique Engine name
-   * @param {String} curationId unique Curation id
-   * @param {Object} newCuration body of the Curation object
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   updateCuration(engineName, curationId, newCuration) {
     return this.client.put(`engines/${encodeURIComponent(engineName)}/curations/${encodeURIComponent(curationId)}`, newCuration)
   }
 
-  /**
-   * Create a new meta engine
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Array[String]} sourceEngines list of engine names to use as source engines
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   createMetaEngine(engineName, sourceEngines) {
     return this.client.post(`engines`, {
       name: engineName,
@@ -283,47 +165,18 @@ class AppSearchClient {
     })
   }
 
-  /**
-   * Delete a curation
-   *
-   * @param {String} engineName unique Engine name
-   * @param {String} curationId unique Curation name
-   * @returns {Promise<Object>} a Promise that returns a result {Object} when resolved, otherwise throws an Error.
-   */
   destroyCuration(engineName, curationId) {
     return this.client.delete(`engines/${encodeURIComponent(engineName)}/curations/${encodeURIComponent(curationId)}`, {})
   }
 
-  /**
-   * Retrieve a schema by engine name
-   *
-   * @param {String} engineName unique Engine name
-   * @returns {Promise<Object>} a Promise that returns the current schema {Object} when resolved, otherwise throws an Error.
-   */
   getSchema(engineName) {
     return this.client.get(`engines/${encodeURIComponent(engineName)}/schema`, {})
   }
 
-  /**
-   * Update an existing schema
-   *
-   * @param {String} engineName unique Engine name
-   * @param {Object} schema body of schema object
-   * @returns {Promise<Object>} a Promise that returns the current schema {Object} when resolved, otherwise throws an Error.
-   */
   updateSchema(engineName, schema) {
     return this.client.post(`engines/${encodeURIComponent(engineName)}/schema`, schema)
   }
 
-  /**
-   * Creates a jwt search key that can be used for authentication to enforce a set of required search options.
-   *
-   * @param {String} apiKey the API Key used to sign the search key
-   * @param {String} apiKeyName the unique name for the API Key
-   * @param {Object} options Object see the <a href="https://swiftype.com/documentation/app-search/authentication#signed">App Search API</a> for supported search options
-   * @param {Object} signOptions Object see the <a href="https://github.com/auth0/node-jsonwebtoken#usage">node-jsonwebtoken</a> for supported sign options
-   * @returns {String} jwt search key
-   */
   static createSignedSearchKey(apiKey, apiKeyName, options = {}, signOptions = {}) {
     const payload = Object.assign({}, options, { api_key_name: apiKeyName })
     return jwt.sign(payload, apiKey, Object.assign({}, signOptions, { algorithm: SIGNED_SEARCH_TOKEN_JWT_ALGORITHM }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/app-search-node",
-  "version": "7.15.1-beta.0",
+  "version": "7.15.1-beta.1",
   "description": "Elastic App Search Node.js client",
   "files": [
     "lib/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/app-search-node",
-  "version": "7.15.0",
+  "version": "7.15.1-beta.0",
   "description": "Elastic App Search Node.js client",
   "files": [
     "lib/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/app-search-node",
-  "version": "7.16.1-beta.0",
+  "version": "7.16.1-beta.1",
   "description": "Elastic App Search Node.js client",
   "main": "lib/appSearch.js",
   "types": "app-search-node.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@elastic/app-search-node",
   "version": "7.16.1-beta.0",
   "description": "Elastic App Search Node.js client",
-  "files": [
-    "lib/"
-  ],
   "main": "lib/appSearch.js",
   "types": "app-search-node.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lib/"
   ],
   "main": "lib/appSearch.js",
+  "types": "app-search-node.d.ts",
   "scripts": {
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/app-search-node",
-  "version": "7.15.1-beta.1",
+  "version": "7.15.2-beta.0",
   "description": "Elastic App Search Node.js client",
   "files": [
     "lib/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/app-search-node",
-  "version": "7.16.0",
+  "version": "7.16.1-beta.0",
   "description": "Elastic App Search Node.js client",
   "files": [
     "lib/"


### PR DESCRIPTION
This add TS definition files to this library.

Closes #13.

This is published with version `@elastic/app-search-node@7.16.1-beta.1` for testing.

```
npm i --save @elastic/app-search-node@7.16.1-beta.1
```

This is the code I used to test these definitions: https://gist.github.com/JasonStoltz/9349e76a4d54607591a3258cfdabc7b8.

These aren't the most comprehensive types in terms of covering all API request and response bodies, users will still have to rely on documentation to some degree. This is primarily since these definitions were hand coded and NOT generated from our Open API spec.

The long term goal is to replace this client with a more comprehensive Enterprise Search client, which is generated from our Open API specs, but for the short term, this will keep this client useable.

Thank you @richbai90 for providing the basis for these types: https://github.com/elastic/app-search-node/issues/13#issuecomment-849176202

![latest](https://user-images.githubusercontent.com/1427475/145884334-ea94d9af-80be-475c-94b5-b86e1a6b2c78.gif)
